### PR TITLE
melodic移行

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,13 +7,11 @@
 下記の環境にて動作確認を行っています。
 
 * Raspberry Pi
-  * Raspberry Pi 3 model B
-  * Raspberry Pi 3 model B+
+  * Raspberry Pi 4 model B
 * Ubuntu
-  * Ubuntu 16.04
-  * Ubuntu MATE 16.04
+  * Ubuntu 18.04
 * ROS 
-  * ROS Kinetic Kame
+  * ROS Melodic Morenia
 * Device Driver
   * [rt-net/RaspberryPiMouse](https://github.com/rt-net/RaspberryPiMouse)
 
@@ -21,9 +19,9 @@
 
 ### 1. 最新版のROSをインストール  
 
-[ROS WiKi](http://wiki.ros.org/kinetic/Installation)を参照するか、以下のスクリプトを使用してROSのインストールを完了させてください。
+[ROS WiKi](http://wiki.ros.org/melodic/Installation)を参照するか、以下のスクリプトを使用してROSのインストールを完了させてください。
 
-* [ryuichiueda/ros_setup_scripts_Ubuntu16.04_server](https://github.com/ryuichiueda/ros_setup_scripts_Ubuntu16.04_server)
+* [ryuichiueda/ros_setup_scripts_Ubuntu18.04_server](https://github.com/ryuichiueda/ros_setup_scripts_Ubuntu18.04_server)
 
 ### 2. デバイスドライバのダウンロードとインストール  
 
@@ -44,7 +42,7 @@ catkin_make
 以下の行を `~/.bashrc` から削除します。
 
 ```
-source /opt/ros/kinetic/setup.bash
+source /opt/ros/melodic/setup.bash
 ```
 
 以下の行を `~/.bashrc` に追加します。

--- a/launch/raspicat.launch
+++ b/launch/raspicat.launch
@@ -1,6 +1,9 @@
 <launch>
   <arg name="imu" default="0" />
-  <include if="$(arg imu)" file="$(find rt_usb_9axis_sensor)/launch/rt_usb_9axis_sensor.launch" />
+  <arg name="port" default="/dev/ttyACM0" />
+  <include if="$(arg imu)" file="$(find rt_usb_9axisimu_driver)/launch/rt_usb_9axisimu_driver.launch">
+    <arg name="port" value="$(arg port)" />
+  </include>
 
   <node pkg="raspicat" name="buzzer" type="buzzer.py" required="true" />
 

--- a/src/leds.cpp
+++ b/src/leds.cpp
@@ -12,13 +12,13 @@ void output(std::ofstream *ofs, bool input)
 void cb(const raspicat::LedValues::ConstPtr& msg)
 {
 	std::ofstream ofs0("/dev/rtled0");
-	output(&ofs0, msg->right_side);
+	output(&ofs0, msg->left_side);
 	std::ofstream ofs1("/dev/rtled1");
-	output(&ofs1, msg->right_forward);
+	output(&ofs1, msg->left_forward);
 	std::ofstream ofs2("/dev/rtled2");
-	output(&ofs2, msg->left_forward);
+	output(&ofs2, msg->right_forward);
 	std::ofstream ofs3("/dev/rtled3");
-	output(&ofs3, msg->left_side);
+	output(&ofs3, msg->right_side);
 }
 
 

--- a/src/lightsensors.cpp
+++ b/src/lightsensors.cpp
@@ -37,8 +37,8 @@ int main(int argc, char **argv)
 		}
 
 		std::ifstream ifs("/dev/rtlightsensor0");
-		ifs >> msg.right_forward >> msg.right_side
-			>> msg.left_side >> msg.left_forward;
+		ifs >> msg.right_side >> msg.right_forward
+			>> msg.left_forward >> msg.left_side;
 
 		msg.sum_forward = msg.left_forward + msg.right_forward;
 		msg.sum_all = msg.sum_forward + msg.left_side + msg.right_side;

--- a/test/travis_test_lightsensors.py
+++ b/test/travis_test_lightsensors.py
@@ -15,7 +15,7 @@ class LightsensorTest(unittest.TestCase):
         self.count += 1
         self.values = data
 
-    def check_values(self,lf,ls,rs,rf):
+    def check_values(self,ls,lf,rf,rs):
         vs = self.values
         self.assertEqual(vs.left_forward, lf, "different value: left_forward")
         self.assertEqual(vs.left_side, ls, "different value: left_side")


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
melodic対応

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
はい。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
#7 [LEDの左右の関係が逆になっている](https://github.com/rt-net/raspicat_ros/issues/7) 
```
PC
~$ roscore
```
```
raspicat
~$ roslaunch raspicat raspicat.launch
~$ rostopic pub /leds raspicat/LedValues "left_side: false
left_forward: false
right_forward: false
right_side: false"
```
#8 [IMUのポート指定およびIMUパッケージの変更](https://github.com/rt-net/raspicat_ros/issues/8)
```
PC
~$ roscore
```
```
raspicat
~$ roslaunch raspicat_slam slam_remote_robot_usb_urg.launch port:=/dev/ttyACM1 *raspicat_slamの方も引数渡せるように修正
```
```
PC
~$ roslaunch raspicat_slam slam_remote_pc.launch
```
#9 [melodic対応のためのREADME、testの修正](https://github.com/rt-net/raspicat_ros/issues/9)
テスト無し

#10 [超音波センサのsideとforwardの関係が逆になっている](https://github.com/rt-net/raspicat_ros/issues/10)
```
PC
~$ roscore
```
```
raspicat
~$ roslaunch raspicat raspicat.launch
~$ rostopic echo /lightsensors
```

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
